### PR TITLE
Allow task start inception

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,9 @@ util.inherits(Orchestrator, EventEmitter);
 		}
 		if (this.doneCallback) {
 			// Avoid calling it multiple times
-			this.doneCallback(err);
+			var doneCallback = this.doneCallback;
+			delete this.doneCallback;
+			doneCallback(err);
 		} else if (err && !this.listeners('err').length) {
 			// No one is listening for the error so speak louder
 			throw err;

--- a/test/start.js
+++ b/test/start.js
@@ -336,5 +336,33 @@ describe('orchestrator', function() {
 			});
 		});
 
+		it('should run subsequent tasks', function(done) {
+			var orchestrator, fn1, fn2, fn3;
+
+			var a = 0;
+			fn1 = function() {
+				a++;
+				orchestrator.start('fn2');
+			}
+
+			fn2 = function() {
+				a++;
+				orchestrator.start('fn3');
+			}
+
+			fn3 = function() {
+				a.should.equal(2);
+				done();
+			}
+			// Arrange
+			orchestrator = new Orchestrator();
+			orchestrator.add('fn1', fn1);
+			orchestrator.add('fn2', fn2);
+			orchestrator.add('fn3', fn3);
+
+			// Act
+			orchestrator.start('fn1');
+		});
+
 	});
 });


### PR DESCRIPTION
While using gulp I crashed into a `RangeError: Maximum call stack size exceeded`.

The following snippet show how you can achieve it without much effort.

``` js
var gulp = require('gulp');
var env = require('gulp-util').env;
var log = require('gulp-util').log;

var a = 0;
gulp.task('root', function() {
  gulp.start('task', function() {
    gulp.start('task', function (){
      gulp.start('final');
    });
  });
});

gulp.task('task', function() { a++ });
gulp.task('final', function() { log(a); });
gulp.task('default', ['root']);
```

I managed to go down the _packages path_ and I end up on line 150 of [orchestrator](https://github.com/robrich/orchestrator/blob/master/index.js#L150) dependency.

The issue seems to be when the _final_ task is called the callback of the previous one isn't cleaned so it enters in a recursive loop.

This "solution" breaks the test "_orchestrator stop() callback should have error when calling callback too many times_". Any feedback is appreciated.
