### PR TITLE
Add description argument for tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,18 @@ util.inherits(Orchestrator, EventEmitter);
 		this.doneCallback = undefined;
 		return this;
 	};
-	Orchestrator.prototype.add = function (name, dep, fn) {
-		if (!fn && typeof dep === 'function') {
-			fn = dep;
+	Orchestrator.prototype.add = function (name, dep, fn, desc) {
+        if (!desc && typeof fn === 'string') {
+            desc = fn;
+        }
+		if ((!fn || typeof fn === 'string') && typeof dep === 'function') {
+            desc = fn;
+		 	fn = dep;
 			dep = undefined;
 		}
+        if (typeof fn === 'string') {
+            fn = undefined;
+        }
 		dep = dep || [];
 		fn = fn || function () {}; // no-op
 		if (!name) {
@@ -55,14 +62,15 @@ util.inherits(Orchestrator, EventEmitter);
 		this.tasks[name] = {
 			fn: fn,
 			dep: dep,
-			name: name
+			name: name,
+            desc: desc
 		};
 		return this;
 	};
-	Orchestrator.prototype.task = function (name, dep, fn) {
+	Orchestrator.prototype.task = function (name, dep, fn, desc) {
 		if (dep || fn) {
 			// alias for add, return nothing rather than this
-			this.add(name, dep, fn);
+			this.add(name, dep, fn, desc);
 		} else {
 			return this.tasks[name];
 		}

--- a/test/add.js
+++ b/test/add.js
@@ -124,5 +124,57 @@ describe('orchestrator', function() {
 			done();
 		});
 
+		it('should accept optional `desc` argument with only dep', function (done) {
+			var orchestrator, name, dep, desc;
+
+			// Arrange
+			name = "name";
+			dep = ['name'];
+            desc = 'description';
+
+			// Act
+			orchestrator = new Orchestrator();
+			orchestrator.add(name, dep, desc);
+
+			// Assert
+			should(orchestrator.tasks.name).have.property('desc', 'description');
+			done();
+		});
+
+		it('should accept optional `desc` argument with only fn', function (done) {
+			var orchestrator, name, fn, desc;
+
+			// Arrange
+			name = "name";
+            fn = function() {};
+            desc = 'description';
+
+			// Act
+			orchestrator = new Orchestrator();
+			orchestrator.add(name, fn, desc);
+
+			// Assert
+			should(orchestrator.tasks.name).have.property('desc', 'description');
+			done();
+		});
+
+		it('should accept optional `desc` argument with both deps and fn', function (done) {
+			var orchestrator, name, dep, fn, desc;
+
+			// Arrange
+			name = "name";
+            dep = ['name']
+            fn = function() {};
+            desc = 'description';
+
+			// Act
+			orchestrator = new Orchestrator();
+			orchestrator.add(name, dep, fn, desc);
+
+			// Assert
+			should(orchestrator.tasks.name).have.property('desc', 'description');
+			done();
+		});
+
 	});
 });


### PR DESCRIPTION
Add optional description argument, allowing to easily describe tasks and create help pages, e.g:

``` javascript
gulp.task('build', function() {...}, 'Build project');

gulp.task('default', function() {
    for (var task in gulp.tasks) {
        console.log(gulp.tasks[task].name, ' - ', gulp.tasks[task].desc);
    }
});

// Output
build - Build project
```
