### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Type: `function`: `function (e) {`
 Passes single argument: `e`: event details
 
 ```javascript
-orchestrator.onAll(orchestrator, function (e) {
+orchestrator.onAll(function (e) {
   // e is the original event args
   // e.src is event name
 });


### PR DESCRIPTION
Modified the onAll example to have the correct arity. For unknown reasons in the example the onAll method was being passed the orchestrator instance in addition to the callback.
