### PR TITLE
Consume stream returned from task

### DIFF
--- a/lib/runTask.js
+++ b/lib/runTask.js
@@ -3,6 +3,7 @@
 "use strict";
 
 var eos = require('end-of-stream');
+var consume = require('stream-consume');
 
 module.exports = function (task, done) {
 	var that = this, finish, cb, isDone = false, start, r;
@@ -47,9 +48,12 @@ module.exports = function (task, done) {
 	} else if (r && typeof r.pipe === 'function') {
 		// wait for stream to end
 
-		eos(r, { error: true, readable: false, writable: false }, function(err){
+		eos(r, { error: true, readable: r.readable, writable: r.writable && !r.readable }, function(err){
 			finish(err, 'stream');
 		});
+
+		// Ensure that the stream completes
+        consume(r);
 
 	} else if (task.length === 0) {
 		// synchronous, function took in args.length parameters, and the callback was extra

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "end-of-stream": "~0.1.5",
-    "sequencify": "~0.0.7"
+    "sequencify": "~0.0.7",
+    "stream-consume": "~0.1.0"
   },
   "devDependencies": {
     "event-stream": "~3.1.5",

--- a/test/streamConsume.js
+++ b/test/streamConsume.js
@@ -1,0 +1,379 @@
+/*jshint node:true */
+/*global describe:false, it:false */
+"use strict";
+
+var Orchestrator = require('../');
+var Stream = require('stream');
+var Readable = Stream.Readable;
+var Writable = Stream.Writable;
+var Duplex = Stream.Duplex;
+var Q = require('q');
+var fs = require('fs');
+var should = require('should');
+require('mocha');
+
+describe('orchestrator', function() {
+	describe('when given a stream', function() {
+
+		it('should consume a Readable stream to relieve backpressure, in objectMode', function(done) {
+			var orchestrator, a;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream with a small buffer...
+				var rs = Readable({objectMode: true, highWaterMark: 2});
+				rs._read = function() {
+					// ...and generate more chunks than fit in that buffer
+					if (a++ < 100) {
+						rs.push(a);
+					} else {
+						rs.push(null);
+					}
+				};
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				// Simple completion of the task is the main criterion here, but check a few things:
+				a.should.be.above(99);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should consume a Readable stream to relieve backpressure', function(done) {
+			var orchestrator, a;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream with a small buffer...
+				var rs = Readable({highWaterMark: 2});
+				rs._read = function() {
+					// ...and generate more chunks than fit in that buffer
+					if (a++ < 100) {
+						rs.push(".");
+					} else {
+						rs.push(null);
+					}
+				};
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				// Simple completion of the task is the main criterion here, but check a few things:
+				a.should.be.above(99);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should detect completion of a Writable stream', function(done) {
+			var orchestrator, a, lengthRead;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			lengthRead = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream...
+				var rs = Readable({highWaterMark: 2});
+				rs._read = function() {
+					if (a++ < 100) {
+						rs.push(".");
+					} else {
+						rs.push(null);
+					}
+				};
+
+				// ...and consume it
+				var ws = Writable();
+				ws._write = function(chunk, enc, next) {
+					lengthRead += chunk.length;
+					next();
+				};
+				rs.pipe(ws);
+
+				// Return the Writable
+				return ws;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				a.should.be.above(99);
+				lengthRead.should.equal(100);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should detect completion of a Writable stream, in objectMode', function(done) {
+			var orchestrator, a, lengthRead;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			lengthRead = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream...
+				var rs = Readable({objectMode: true, highWaterMark: 2});
+				rs._read = function() {
+					if (a++ < 100) {
+						rs.push(a);
+					} else {
+						rs.push(null);
+					}
+				};
+
+				// ...and consume it
+				var ws = Writable({objectMode: true});
+				ws._write = function(chunk, enc, next) {
+					lengthRead++;
+					next();
+				};
+				rs.pipe(ws);
+
+				// Return the Writable
+				return ws;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				a.should.be.above(99);
+				lengthRead.should.equal(100);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should handle an intermediate Readable stream being returned', function(done) {
+			var orchestrator, a, lengthRead;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			lengthRead = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream...
+				var rs = Readable({highWaterMark: 2});
+				rs._read = function() {
+					if (a++ < 100) {
+						rs.push(".");
+					} else {
+						rs.push(null);
+					}
+				};
+
+				// ...and consume it
+				var ws = Writable();
+				ws._write = function(chunk, enc, next) {
+					lengthRead += chunk.length;
+					next();
+				};
+				rs.pipe(ws);
+
+				// Return the Readable
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				a.should.be.above(99);
+				// Ensure all data was received by the Writable
+				lengthRead.should.equal(100);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should handle an intermediate Readable stream being returned, in objectMode', function(done) {
+			var orchestrator, a, lengthRead;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+			a = 0;
+			lengthRead = 0;
+			orchestrator.add('test', function() {
+				// Create a Readable stream...
+				var rs = Readable({objectMode: true, highWaterMark: 2});
+				rs._read = function() {
+					if (a++ < 100) {
+						rs.push(a);
+					} else {
+						rs.push(null);
+					}
+				};
+
+				// ...and consume it
+				var ws = Writable({objectMode: true});
+				ws._write = function(chunk, enc, next) {
+					lengthRead++;
+					next();
+				};
+				rs.pipe(ws);
+
+				// Return the Readable
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				a.should.be.above(99);
+				// Ensure all data was received by the Writable
+				lengthRead.should.equal(100);
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should require the Readable side of a Duplex stream to be closed to trigger completion', function(done) {
+			var orchestrator;
+			var readableClosed = false;
+			var readCalled = false;
+			var writableClosed = false;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+
+			orchestrator.add('test', function() {
+				var ds = Duplex();
+				ds._write = function(chunk, enc, next) {
+					next();
+				};
+
+				function closeReadable() {
+					// Delay closing the Readable side
+					setTimeout(function() {
+						readableClosed = true;
+						ds.push(null);
+					}, 1);
+				}
+
+				ds.on("finish", function() {
+					writableClosed = true;
+					if (readCalled)
+						closeReadable();
+				});
+
+
+				ds._read = function() {
+					readCalled = true;
+					// Only close the Readable if the Writable has already been closed
+					if (writableClosed)
+						closeReadable();
+				}
+
+				// Close the Writable side - after returning the stream, so that orchestrator sees the close
+				setTimeout(function() {
+					ds.end();
+				}, 1);
+
+				// Return the Duplex
+				return ds;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				readableClosed.should.be.true;
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should handle a classic stream that is not piped anywhere', function(done) {
+			var orchestrator;
+			var readableClosed = false;
+			var readCalled = false;
+			var writableClosed = false;
+			var i;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+
+			orchestrator.add('test', function() {
+				var rs = new Stream();
+
+				process.nextTick(function() {
+					for (i = 1; i <= 100; i++) {
+						rs.emit("data", i);
+					}
+					rs.emit("end");
+				});
+
+				// Return the Readable
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				should.not.exist(err);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+		it('should handle a classic stream that is piped somewhere', function(done) {
+			var orchestrator;
+			var readableClosed = false;
+			var readCalled = false;
+			var writableClosed = false;
+			var lengthRead = 0;
+			var i;
+
+			// Arrange
+			orchestrator = new Orchestrator();
+
+			orchestrator.add('test', function() {
+				var rs = new Stream();
+
+				process.nextTick(function() {
+					for (i = 0; i < 100; i++) {
+						rs.emit("data", i);
+					}
+					rs.emit("end");
+				});
+
+				var ws = new Writable({objectMode: true, highWaterMark: 5});
+				ws._write = function(chunk, enc, next) {
+					lengthRead++;
+					next();
+				};
+
+				rs.pipe(ws);
+
+				// Return the Readable
+				return rs;
+			});
+
+			// Act
+			orchestrator.start('test', function(err) {
+				// Assert
+				should.not.exist(err);
+				lengthRead.should.equal(100);
+				orchestrator.isRunning.should.equal(false);
+				done();
+			});
+		});
+
+	});
+});


### PR DESCRIPTION
Fixes #48: Consume streams returned by tasks, to relieve
back pressure and allow stream to be fully processed.

Please see [my comment on issue #48](https://github.com/orchestrator/orchestrator/issues/48#issuecomment-49500707) for further detail.
